### PR TITLE
Add support for including fast-rsa-engine as a no-op dependency on MRI

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,22 +1,25 @@
 #-*- mode: ruby -*-
 
 require 'bundler/gem_tasks'
-require 'ruby-maven'
 
-desc "Pack fast-rsa-engine.jar with the compiled classes"
-task :jar do
-  RubyMaven.exec('prepare-package', '-Dmaven.test.skip')
+if RUBY_PLATFORM == 'java'
+  require 'ruby-maven'
+
+  desc "Pack fast-rsa-engine.jar with the compiled classes"
+  task :jar do
+    RubyMaven.exec('prepare-package', '-Dmaven.test.skip')
+  end
 end
 
 require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new
 
-task :default => [ :jar, :spec ]
-
 require 'rubygems/package_task'
 Gem::PackageTask.new( eval File.read( './fast-rsa-engine.gemspec' ) ) do
-  desc 'Pack leafy-metrics.gem'
+  desc 'Pack fast-rsa-engine.gem'
   task :package => [:jar]
 end
+
+task :default => [ :jar, :spec ]
 
 # vim: syntax=ruby

--- a/fast-rsa-engine.gemspec
+++ b/fast-rsa-engine.gemspec
@@ -2,10 +2,9 @@
 
 Gem::Specification.new do |s|
   s.name = 'fast-rsa-engine'
-  s.version = '0.1.0'
+  s.version = '0.1.1'
   s.author = 'Christian Meieier'
-  s.email = [ 'christian.meier@lookout.com' ]
-  s.platform = 'java'
+  s.email = [ 'christian.meier@lookout.com', 'rtyler.croy@lookout.com' ]
 
   s.license = 'MIT'
   s.summary = %q(replaces the RSA signature and RSA ciphers from jruby-openssl by the must faster implementation of them)
@@ -14,16 +13,22 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split($/)
 
-  BC_VERSION = '1.50'
-  # needed for runtime
-  s.requirements << "jar com.squareup.jnagmp:bouncycastle-rsa, 1.0.0"
-  # needed for compilation
-  s.requirements << "jar org.bouncycastle:bcpkix-jdk15on, #{BC_VERSION}, :scope => :provided"
-  s.requirements << "jar org.bouncycastle:bcprov-jdk15on, #{BC_VERSION}, :scope => :provided"
-  s.requirements << "pom org.jruby:jruby-core, 1.7.21, :scope => :provided"
+  if RUBY_PLATFORM == 'java'
+    unless defined?(BC_VERSION)
+      BC_VERSION = '1.50'
+    end
+    s.platform = 'java'
+    # needed for runtime
+    s.requirements << "jar com.squareup.jnagmp:bouncycastle-rsa, 1.0.0"
+    # needed for compilation
+    s.requirements << "jar org.bouncycastle:bcpkix-jdk15on, #{BC_VERSION}, :scope => :provided"
+    s.requirements << "jar org.bouncycastle:bcprov-jdk15on, #{BC_VERSION}, :scope => :provided"
+    s.requirements << "pom org.jruby:jruby-core, 1.7.21, :scope => :provided"
 
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
-  s.add_development_dependency 'ruby-maven', '~> 3.3'
+    s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
+    s.add_development_dependency 'ruby-maven', '~> 3.3'
+  end
+
   s.add_development_dependency 'rspec', '~> 3.3'
   s.add_development_dependency 'rake', '~> 10.2'
 end

--- a/lib/fast-rsa-engine.rb
+++ b/lib/fast-rsa-engine.rb
@@ -1,13 +1,17 @@
-require 'fast-rsa-engine_jars.rb'
-require 'fast-rsa-engine.jar'
-require 'openssl'
+if RUBY_PLATFORM == 'java'
+  require 'fast-rsa-engine_jars.rb'
+  require 'fast-rsa-engine.jar'
+  require 'openssl'
 
-# keep the default name space clean and use tap
-tap do
-  engines = Java::OrgJrubyExtOpenssl::SecurityHelper.java_class.declared_field 'implEngines'
-  engines.accessible = true
-  com.github.lookout.fastrsa.SecurityHelperMap.setup( engines.value( Java::OrgJrubyExtOpenssl::SecurityHelper ))
-  use_internal = Java::OrgJrubyExtOpenssl::SecurityHelper.java_class.declared_field 'tryCipherInternal'
-  use_internal.accessible = true
-  use_internal.set_value( Java::OrgJrubyExtOpenssl::SecurityHelper, true )
+  # keep the default name space clean and use tap
+  tap do
+    engines = Java::OrgJrubyExtOpenssl::SecurityHelper.java_class.declared_field 'implEngines'
+    engines.accessible = true
+    com.github.lookout.fastrsa.SecurityHelperMap.setup( engines.value( Java::OrgJrubyExtOpenssl::SecurityHelper ))
+    use_internal = Java::OrgJrubyExtOpenssl::SecurityHelper.java_class.declared_field 'tryCipherInternal'
+    use_internal.accessible = true
+    use_internal.set_value( Java::OrgJrubyExtOpenssl::SecurityHelper, true )
+  end
+else
+  $stderr.write("fast-rsa-engine does not affect MRI")
 end


### PR DESCRIPTION
This will allow users of this gem to include it as a dependency, even if all of
their use-cases aren't on the JVM. Obviating the need for if statements all
over the place just to get faster RSA ops