### PR TITLE
Fix jar-dependencies gem

### DIFF
--- a/fast-rsa-engine.gemspec
+++ b/fast-rsa-engine.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     s.requirements << "jar org.bouncycastle:bcprov-jdk15on, #{BC_VERSION}, :scope => :provided"
     s.requirements << "pom org.jruby:jruby-core, 1.7.21, :scope => :provided"
 
-    s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
+    s.add_runtime_dependency 'jar-dependencies', '0.2.2'
     s.add_runtime_dependency 'jruby-openssl', '~> 0.9.10'
     s.add_development_dependency 'ruby-maven', '~> 3.3'
   end


### PR DESCRIPTION
`s.add_runtime_dependency 'jar-dependencies', '~> 0.1'` will result in the installation of 0.3.9 which is the latest version. The README development instructions only work with 0.2.2