### PR TITLE
Pin jar-dependencies gem to `0.3.2` in gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,13 @@ or
 
 ## developement
 
-get all the gems and jars in place
+Get all the gems and jars in place.
 
-    gem install jar-dependencies --development
     bundle install
 
-for running all specs
+Build jar and run all specs.
 
-	rake
+    bundle exec rake
 
 ## meta-fu
 

--- a/fast-rsa-engine.gemspec
+++ b/fast-rsa-engine.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
     s.requirements << "jar org.bouncycastle:bcprov-jdk15on, #{BC_VERSION}, :scope => :provided"
     s.requirements << "pom org.jruby:jruby-core, 1.7.21, :scope => :provided"
 
-    s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
+    s.add_runtime_dependency 'jar-dependencies', '0.3.2'
     s.add_runtime_dependency 'jruby-openssl', '~> 0.9.10'
     s.add_development_dependency 'ruby-maven', '~> 3.3'
   end


### PR DESCRIPTION
- Pin jar-dependencies gem to `0.3.2` as it does not follow semvar and will prevent gem development.
- Update development steps in README.