### PR TITLE
Update gem development steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ or
 ## developement
 
 Get all the gems and jars in place.
-
+    
+    gem install jar-dependencies --development
     bundle install
 
 Build jar and run all specs.


### PR DESCRIPTION
I need to put back `gem install jar-dependencies --development` to be in line with instructions on the `jar-dependencies` gem README

https://github.com/mkristian/jar-dependencies#some-drawbacks