### PR TITLE
Update dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ pom*
 *_jars.rb
 *lock
 .mvn
+.ruby-gemset
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - jruby-1.7.19
   - jruby-1.7.21
   - jruby-9.0.0.0
+  - jruby-9.1.8.0
 jdk:
   - openjdk7
   - oraclejdk8

--- a/fast-rsa-engine.gemspec
+++ b/fast-rsa-engine.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'fast-rsa-engine'
-  s.version = '0.3.3'
+  s.version = '0.4.0'
   s.author = 'Christian Meier'
   s.email = [ 'christian.meier@lookout.com', 'rtyler.croy@lookout.com' ]
 
@@ -17,18 +17,18 @@ Gem::Specification.new do |s|
     s.files << 'lib/fast-rsa-engine.jar'
     s.files << 'lib/fast-rsa-engine_jars.rb'
     unless defined?(BC_VERSION)
-      BC_VERSION = '1.50'
+      BC_VERSION = '1.56'
     end
     s.platform = 'java'
     # needed for runtime
-    s.requirements << "jar com.squareup.jnagmp:bouncycastle-rsa, 1.0.1"
+    s.requirements << "jar com.squareup.jnagmp:bouncycastle-rsa, 2.0.0"
     # needed for compilation
     s.requirements << "jar org.bouncycastle:bcpkix-jdk15on, #{BC_VERSION}, :scope => :provided"
     s.requirements << "jar org.bouncycastle:bcprov-jdk15on, #{BC_VERSION}, :scope => :provided"
-    s.requirements << "pom org.jruby:jruby-core, 1.7.21, :scope => :provided"
+    s.requirements << "pom org.jruby:jruby-core, 9.1.8.0, :scope => :provided"
 
     s.add_runtime_dependency 'jar-dependencies', '>= 0.3.10', '< 1.1'
-    s.add_runtime_dependency 'jruby-openssl', '~> 0.9.10'
+    s.add_runtime_dependency 'jruby-openssl', '~> 0.9.20'
     s.add_development_dependency 'ruby-maven', '~> 3.3'
   end
 


### PR DESCRIPTION
This updates BouncyCastle to 1.56, jruby-openssl to 0.9.20, and
jruby-core to 9.1.8.0 so that we can get a consistent version of the
BouncyCastle Jar when running with newer JRuby.

This also bumps bouncycastle-rsa to 2.0.0. We don't care about the new
functions for now, but good to update.