### PR TITLE
Loosen jruby-openssl pin.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 language: ruby
 install: gem install bundler -v '~>1.10'; bundle install
 rvm:
-  - jruby-1.7.19
-  - jruby-1.7.21
-  - jruby-9.0.0.0
-  - jruby-9.1.8.0
+  - jruby-1.7.27
+  - jruby-9.1.17.0
 jdk:
   - openjdk7
   - oraclejdk8
@@ -12,3 +10,5 @@ matrix:
   include:
     - rvm: 1.9.3
       jdk: openjdk7
+    - rvm: jruby-9.2.0.0
+      jdk: openjdk8

--- a/fast-rsa-engine.gemspec
+++ b/fast-rsa-engine.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'fast-rsa-engine'
-  s.version = '0.4.1'
+  s.version = '0.4.2'
   s.author = 'Christian Meier'
   s.email = [ 'christian.meier@lookout.com', 'rtyler.croy@lookout.com' ]
 
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     s.requirements << "pom org.jruby:jruby-core, 9.1.8.0, :scope => :provided"
 
     s.add_runtime_dependency 'jar-dependencies', '>= 0.3.10', '< 1.1'
-    s.add_runtime_dependency 'jruby-openssl', '~> 0.9.20'
+    s.add_runtime_dependency 'jruby-openssl', '>= 0.9.20', '< 0.11'
     s.add_development_dependency 'ruby-maven', '~> 3.3'
   end
 


### PR DESCRIPTION
Version 0.10 removes support for BC 1.55, jruby-1.6, and java6 while
preparing the way for adding java 9/10 support.